### PR TITLE
ci: add automated NuGet package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: publish to nuget
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+jobs:
+  publish:
+    name: pack and publish
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 8.0.x
+
+      - name: pack
+        run: dotnet pack -c Release src/SharpCLI/SharpCLI.csproj -o ./artifacts
+
+      - name: nuget push
+        working-directory: artifacts
+        run: dotnet nuget push *.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/SharpCLI.sln
+++ b/SharpCLI.sln
@@ -9,6 +9,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpCLI", "src\SharpCLI\Sh
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "artifacts", "artifacts", "{2C378BF0-F9AA-42DD-A098-54F1F64ED42A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github/workflows", ".github/workflows", "{89CF2027-24B3-49A7-98BD-C5D304F82D17}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\publish.yml = .github\workflows\publish.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
Adds GitHub Actions workflow to automatically publish SharpCLI package to NuGet on master branch pushes or manual workflow dispatch