### PR TITLE
fix: implement trimming-safe default value generation and bump to v1.2.1

### DIFF
--- a/src/SharpCLI/SharpCLI.csproj
+++ b/src/SharpCLI/SharpCLI.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>SharpCLI</PackageId>
-    <Version>1.1.1</Version>
+    <Version>1.2.1</Version>
     <Title>SharpCli - Modern CLI Framework for .NET</Title>
     <Summary>Attribute-based CLI framework for .NET with automatic parsing and help generation</Summary>
     <Description>A modern, attribute-based CLI framework for .NET that makes building command-line applications simple and intuitive. Transform your methods into powerful CLI commands using simple attributes with automatic argument parsing, help generation, and async support.</Description>


### PR DESCRIPTION
- Replace Activator.CreateInstance with compiled expression trees to eliminate IL2067 trimming warnings
- Add thread-safe caching using ConcurrentDictionary for improved performance on repeated calls
- Implement AOT-compatible default value generation using Expression.Default and Lambda compilation
- Update comprehensive XML documentation with examples and technical details
- Bump package version from 1.1.1 to 1.2.1

Resolves trimming compatibility issues for .NET 8.0 target framework while maintaining full compatibility with netstandard2.0.