### PR TITLE
feat: improve type safety and code quality in SharpCliHost

### DIFF
--- a/src/SharpCLI/Models/ICommandsContainer.cs
+++ b/src/SharpCLI/Models/ICommandsContainer.cs
@@ -1,0 +1,21 @@
+﻿namespace SharpCLI;
+
+/// <summary>
+/// Marker interface for classes containing CLI command methods.
+/// </summary>
+/// <remarks>
+/// Implement this interface on classes that contain methods decorated with [Command] attributes.
+/// This prevents accidentally passing Type objects instead of class instances.
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MyCommands : ICommandContainer
+/// {
+///     [Command("hello")]
+///     public void SayHello() => Console.WriteLine("Hello!");
+/// }
+/// 
+/// host.RegisterCommands(new MyCommands());
+/// </code>
+/// </example>
+public interface ICommandsContainer;


### PR DESCRIPTION
- Add ICommandsContainer interface constraint to RegisterCommands methods for better type safety
- Replace Dictionary.ContainsKey + indexer with TryGetValue pattern for better performance
- Remove redundant null check in required argument validation (result[argIndex] is never null)
- Improve code formatting and comments for better readability
- Rename parameter from 'commandsObject' to 'commandsesObject' for consistency