### PR TITLE
workflow: change trigger from master push to version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: publish to nuget
 on:
   workflow_dispatch:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*'
 jobs:
   publish:
     name: pack and publish


### PR DESCRIPTION
- Update publish workflow to trigger on 'v*' tags
- Remove automatic publishing on master branch pushes
- Enable controlled releases tied to version tagging