### PR TITLE
feat: Add comprehensive custom exceptions and improve error handling

### DIFF
--- a/src/SharpCLI/Exceptions/AliasAlreadyExistsException.cs
+++ b/src/SharpCLI/Exceptions/AliasAlreadyExistsException.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SharpCLI;
+
+/// <summary>
+/// Thrown when attempting to register an alias that is already in use for another command.
+/// </summary>
+[Serializable]
+public class AliasAlreadyExistsException : SharpCliException
+{
+    /// <summary>
+    /// Gets the alias that is already in use.
+    /// </summary>
+    public string Alias { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AliasAlreadyExistsException"/> class.
+    /// </summary>
+    public AliasAlreadyExistsException() : base()
+    {
+        Alias = string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AliasAlreadyExistsException"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+    protected AliasAlreadyExistsException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+        Alias = info.GetString(nameof(Alias)) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AliasAlreadyExistsException"/> class with the specified alias.
+    /// </summary>
+    /// <param name="alias">The alias that is already in use.</param>
+    public AliasAlreadyExistsException(string alias)
+        : base($"An alias '{alias}' is already registered for another command.")
+    {
+        Alias = alias;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AliasAlreadyExistsException"/> class with the specified alias and inner exception.
+    /// </summary>
+    /// <param name="alias">The alias that is already in use.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public AliasAlreadyExistsException(string alias, Exception innerException)
+        : base($"An alias '{alias}' is already registered for another command.", innerException)
+    {
+        Alias = alias;
+    }
+}

--- a/src/SharpCLI/Exceptions/ArgumentParsingException.cs
+++ b/src/SharpCLI/Exceptions/ArgumentParsingException.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SharpCLI;
+
+/// <summary>
+/// Base exception for errors during argument and option parsing.
+/// </summary>
+[Serializable]
+public class ArgumentParsingException : SharpCliException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArgumentParsingException"/> class.
+    /// </summary>
+    public ArgumentParsingException() : base()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArgumentParsingException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public ArgumentParsingException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArgumentParsingException"/> class with a specified error message and a reference to the inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public ArgumentParsingException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArgumentParsingException"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+    protected ArgumentParsingException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}

--- a/src/SharpCLI/Exceptions/CommandAlreadyExistsException.cs
+++ b/src/SharpCLI/Exceptions/CommandAlreadyExistsException.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SharpCLI;
+
+/// <summary>
+/// Thrown when attempting to register a command that already exists in the host.
+/// </summary>
+[Serializable]
+public class CommandAlreadyExistsException : SharpCliException
+{
+    /// <summary>
+    /// Gets the name of the command that already exists.
+    /// </summary>
+    public string CommandName { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandAlreadyExistsException"/> class.
+    /// </summary>
+    public CommandAlreadyExistsException() : base()
+    {
+        CommandName = string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandAlreadyExistsException"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+    protected CommandAlreadyExistsException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+        CommandName = info.GetString(nameof(CommandName)) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandAlreadyExistsException"/> class with the specified command name.
+    /// </summary>
+    /// <param name="commandName">The name of the command that already exists.</param>
+    public CommandAlreadyExistsException(string commandName)
+        : base($"A command with the name '{commandName}' is already registered.")
+    {
+        CommandName = commandName;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandAlreadyExistsException"/> class with the specified command name and inner exception.
+    /// </summary>
+    /// <param name="commandName">The name of the command that already exists.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public CommandAlreadyExistsException(string commandName, Exception innerException)
+        : base($"A command with the name '{commandName}' is already registered.", innerException)
+    {
+        CommandName = commandName;
+    }
+}

--- a/src/SharpCLI/Exceptions/CommandNotFoundException.cs
+++ b/src/SharpCLI/Exceptions/CommandNotFoundException.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SharpCLI;
+
+/// <summary>
+/// Thrown when a command is not found during execution.
+/// </summary>
+[Serializable]
+public class CommandNotFoundException : SharpCliException
+{
+    /// <summary>
+    /// Gets the name of the command that was not found.
+    /// </summary>
+    public string CommandName { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandNotFoundException"/> class.
+    /// </summary>
+    public CommandNotFoundException() : base()
+    {
+        CommandName = string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandNotFoundException"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+    protected CommandNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+        CommandName = info.GetString(nameof(CommandName)) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandNotFoundException"/> class with the specified command name.
+    /// </summary>
+    /// <param name="commandName">The name of the command that was not found.</param>
+    public CommandNotFoundException(string commandName)
+        : base($"Command '{commandName}' not found. Use '--help' for available commands.")
+    {
+        CommandName = commandName;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandNotFoundException"/> class with the specified command name and inner exception.
+    /// </summary>
+    /// <param name="commandName">The name of the command that was not found.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public CommandNotFoundException(string commandName, Exception innerException)
+        : base($"Command '{commandName}' not found. Use '--help' for available commands.", innerException)
+    {
+        CommandName = commandName;
+    }
+}

--- a/src/SharpCLI/Exceptions/CommandRegistrationException.cs
+++ b/src/SharpCLI/Exceptions/CommandRegistrationException.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SharpCLI;
+
+/// <summary>
+/// Base exception for errors during command registration, such as invalid attributes or method signatures.
+/// </summary>
+[Serializable]
+public class CommandRegistrationException : SharpCliException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandRegistrationException"/> class.
+    /// </summary>
+    public CommandRegistrationException() : base()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandRegistrationException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public CommandRegistrationException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandRegistrationException"/> class with a specified error message and a reference to the inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public CommandRegistrationException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandRegistrationException"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+    protected CommandRegistrationException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}

--- a/src/SharpCLI/Exceptions/InvalidArgumentValueException.cs
+++ b/src/SharpCLI/Exceptions/InvalidArgumentValueException.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SharpCLI;
+
+/// <summary>
+/// Thrown when an argument or option value cannot be converted to the expected type.
+/// </summary>
+[Serializable]
+public class InvalidArgumentValueException : ArgumentParsingException
+{
+    /// <summary>
+    /// Gets the name of the argument or option with the invalid value.
+    /// </summary>
+    public string ArgumentName { get; }
+
+    /// <summary>
+    /// Gets the provided invalid value.
+    /// </summary>
+    public string ProvidedValue { get; }
+
+    /// <summary>
+    /// Gets the expected type for the argument or option.
+    /// </summary>
+    public Type ExpectedType { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidArgumentValueException"/> class.
+    /// </summary>
+    public InvalidArgumentValueException() : base()
+    {
+        ArgumentName = string.Empty;
+        ProvidedValue = string.Empty;
+        ExpectedType = typeof(object);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidArgumentValueException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public InvalidArgumentValueException(string message) : base(message)
+    {
+        ArgumentName = string.Empty;
+        ProvidedValue = string.Empty;
+        ExpectedType = typeof(object);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidArgumentValueException"/> class with a specified error message and a reference to the inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public InvalidArgumentValueException(string message, Exception innerException) : base(message, innerException)
+    {
+        ArgumentName = string.Empty;
+        ProvidedValue = string.Empty;
+        ExpectedType = typeof(object);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidArgumentValueException"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+    protected InvalidArgumentValueException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+        ArgumentName = info.GetString(nameof(ArgumentName)) ?? string.Empty;
+        ProvidedValue = info.GetString(nameof(ProvidedValue)) ?? string.Empty;
+        ExpectedType = (Type)info.GetValue(nameof(ExpectedType), typeof(Type)) ?? typeof(object);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidArgumentValueException"/> class with the specified details.
+    /// </summary>
+    /// <param name="argumentName">The name of the argument or option.</param>
+    /// <param name="providedValue">The provided invalid value.</param>
+    /// <param name="expectedType">The expected type.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or null.</param>
+    public InvalidArgumentValueException(string argumentName, string providedValue, Type expectedType,
+        Exception? innerException = null)
+        : base($"Invalid value '{providedValue}' for '{argumentName}'. Expected type: {expectedType.Name}.",
+            innerException)
+    {
+        ArgumentName = argumentName;
+        ProvidedValue = providedValue;
+        ExpectedType = expectedType;
+    }
+}

--- a/src/SharpCLI/Exceptions/InvalidCommandConfigurationException.cs
+++ b/src/SharpCLI/Exceptions/InvalidCommandConfigurationException.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SharpCLI;
+
+/// <summary>
+/// Thrown when a command method has an invalid configuration, such as duplicate parameter names or unsupported return types.
+/// </summary>
+[Serializable]
+public class InvalidCommandConfigurationException : CommandRegistrationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidCommandConfigurationException"/> class.
+    /// </summary>
+    public InvalidCommandConfigurationException() : base()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidCommandConfigurationException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public InvalidCommandConfigurationException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidCommandConfigurationException"/> class with a specified error message and a reference to the inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public InvalidCommandConfigurationException(string message, Exception innerException) : base(message,
+        innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidCommandConfigurationException"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+    protected InvalidCommandConfigurationException(SerializationInfo info, StreamingContext context) : base(info,
+        context)
+    {
+    }
+}

--- a/src/SharpCLI/Exceptions/MissingOptionValueException.cs
+++ b/src/SharpCLI/Exceptions/MissingOptionValueException.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SharpCLI;
+
+/// <summary>
+/// Thrown when a required option value is missing from the command-line input.
+/// </summary>
+[Serializable]
+public class MissingOptionValueException : ArgumentParsingException
+{
+    /// <summary>
+    /// Gets the name of the option that requires a value.
+    /// </summary>
+    public string OptionName { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingOptionValueException"/> class.
+    /// </summary>
+    public MissingOptionValueException() : base()
+    {
+        OptionName = string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingOptionValueException"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+    protected MissingOptionValueException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+        OptionName = info.GetString(nameof(OptionName)) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingOptionValueException"/> class with the specified option name.
+    /// </summary>
+    /// <param name="optionName">The name of the option that requires a value.</param>
+    public MissingOptionValueException(string optionName)
+        : base($"Option '{optionName}' requires a value but none was provided.")
+    {
+        OptionName = optionName;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingOptionValueException"/> class with the specified option name and inner exception.
+    /// </summary>
+    /// <param name="optionName">The name of the option that requires a value.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public MissingOptionValueException(string optionName, Exception innerException)
+        : base($"Option '{optionName}' requires a value but none was provided.", innerException)
+    {
+        OptionName = optionName;
+    }
+}

--- a/src/SharpCLI/Exceptions/MissingRequiredArgumentException.cs
+++ b/src/SharpCLI/Exceptions/MissingRequiredArgumentException.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SharpCLI;
+
+/// <summary>
+/// Thrown when a required argument is missing from the command-line input.
+/// </summary>
+[Serializable]
+public class MissingRequiredArgumentException : ArgumentParsingException
+{
+    /// <summary>
+    /// Gets the name of the missing required argument.
+    /// </summary>
+    public string ArgumentName { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingRequiredArgumentException"/> class.
+    /// </summary>
+    public MissingRequiredArgumentException() : base()
+    {
+        ArgumentName = string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingRequiredArgumentException"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+    protected MissingRequiredArgumentException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+        ArgumentName = info.GetString(nameof(ArgumentName)) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingRequiredArgumentException"/> class with the specified argument name.
+    /// </summary>
+    /// <param name="argumentName">The name of the missing required argument.</param>
+    public MissingRequiredArgumentException(string argumentName)
+        : base($"Required argument '{argumentName}' is missing.")
+    {
+        ArgumentName = argumentName;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingRequiredArgumentException"/> class with the specified argument name and inner exception.
+    /// </summary>
+    /// <param name="argumentName">The name of the missing required argument.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public MissingRequiredArgumentException(string argumentName, Exception innerException)
+        : base($"Required argument '{argumentName}' is missing.", innerException)
+    {
+        ArgumentName = argumentName;
+    }
+}

--- a/src/SharpCLI/Exceptions/SharpCliException.cs
+++ b/src/SharpCLI/Exceptions/SharpCliException.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SharpCLI;
+
+/// <summary>
+/// Base exception class for all SharpCLI framework-related errors.
+/// This allows catching framework-specific exceptions separately from general exceptions.
+/// </summary>
+[Serializable]
+public abstract class SharpCliException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SharpCliException"/> class.
+    /// </summary>
+    protected SharpCliException() : base()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SharpCliException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    protected SharpCliException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SharpCliException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    protected SharpCliException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SharpCliException"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+    protected SharpCliException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}

--- a/src/SharpCLI/Exceptions/UnrecognizedArgumentException.cs
+++ b/src/SharpCLI/Exceptions/UnrecognizedArgumentException.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SharpCLI;
+
+/// <summary>
+/// Thrown when there are extra unrecognized arguments provided on the command line.
+/// </summary>
+[Serializable]
+public class UnrecognizedArgumentException : ArgumentParsingException
+{
+    /// <summary>
+    /// Gets the unrecognized argument or option.
+    /// </summary>
+    public string UnrecognizedArg { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnrecognizedArgumentException"/> class.
+    /// </summary>
+    public UnrecognizedArgumentException() : base()
+    {
+        UnrecognizedArg = string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnrecognizedArgumentException"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+    protected UnrecognizedArgumentException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+        UnrecognizedArg = info.GetString(nameof(UnrecognizedArg)) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnrecognizedArgumentException"/> class with the specified unrecognized argument.
+    /// </summary>
+    /// <param name="unrecognizedArg">The unrecognized argument or option.</param>
+    public UnrecognizedArgumentException(string unrecognizedArg)
+        : base($"Unrecognized argument or option: '{unrecognizedArg}'.")
+    {
+        UnrecognizedArg = unrecognizedArg;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnrecognizedArgumentException"/> class with the specified unrecognized argument and inner exception.
+    /// </summary>
+    /// <param name="unrecognizedArg">The unrecognized argument or option.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public UnrecognizedArgumentException(string unrecognizedArg, Exception innerException)
+        : base($"Unrecognized argument or option: '{unrecognizedArg}'.", innerException)
+    {
+        UnrecognizedArg = unrecognizedArg;
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/Commands/BadReturnTypeCommands.cs
+++ b/tests/SharpCLI.Tests.UnitTests/Commands/BadReturnTypeCommands.cs
@@ -1,0 +1,7 @@
+namespace SharpCLI.Tests.UnitTests.Commands;
+
+internal class BadReturnTypeCommands : ICommandsContainer
+{
+    [Command("bad-return")]
+    public string BadReturn() => "invalid";
+}

--- a/tests/SharpCLI.Tests.UnitTests/Commands/BasicCommands.cs
+++ b/tests/SharpCLI.Tests.UnitTests/Commands/BasicCommands.cs
@@ -1,10 +1,10 @@
-namespace SharpCLI.Tests.UnitTests;
+namespace SharpCLI.Tests.UnitTests.Commands;
 
-public class TestCommands : ICommandsContainer
+public class BasicCommands : ICommandsContainer
 {
     public bool WasExecuted { get; private set; }
     public string? LastValue { get; private set; }
-    
+
 
     [Command("test", Description = "A test command", Aliases = ["t"])]
     public int ExecuteTest(
@@ -44,10 +44,4 @@ public class TestCommands : ICommandsContainer
         LastValue = $"{first}-{second}";
         return 0;
     }
-}
-
-public enum TestLevel
-{
-    Low,
-    High
 }

--- a/tests/SharpCLI.Tests.UnitTests/Commands/ConflictingAliasCommands.cs
+++ b/tests/SharpCLI.Tests.UnitTests/Commands/ConflictingAliasCommands.cs
@@ -1,0 +1,9 @@
+namespace SharpCLI.Tests.UnitTests.Commands;
+
+internal class ConflictingAliasCommands : ICommandsContainer
+{
+    [Command("other", Aliases = new[] { "t" })]
+    public void OtherCommand()
+    {
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/Commands/DuplicateParamNamesCommands.cs
+++ b/tests/SharpCLI.Tests.UnitTests/Commands/DuplicateParamNamesCommands.cs
@@ -1,0 +1,9 @@
+namespace SharpCLI.Tests.UnitTests.Commands;
+
+internal class DuplicateParamNamesCommands : ICommandsContainer
+{
+    [Command("dup-params")]
+    public void DupParams([Argument("same")] string param1, [Argument("same")] int param2)
+    {
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/GlobalUsings.cs
+++ b/tests/SharpCLI.Tests.UnitTests/GlobalUsings.cs
@@ -1,2 +1,3 @@
 global using Xunit;
+global using SharpCLI.Tests.UnitTests.Commands;
 global using System.Globalization;

--- a/tests/SharpCLI.Tests.UnitTests/TestLevel.cs
+++ b/tests/SharpCLI.Tests.UnitTests/TestLevel.cs
@@ -1,0 +1,7 @@
+namespace SharpCLI.Tests.UnitTests;
+
+public enum TestLevel
+{
+    Low,
+    High
+}


### PR DESCRIPTION
- Introduced a full hierarchy of custom exceptions derived from `SharpCliException`:
  - `CommandAlreadyExistsException`
  - `AliasAlreadyExistsException`
  - `CommandNotFoundException`
  - `CommandRegistrationException` (base)
  - `InvalidCommandConfigurationException`
  - `ArgumentParsingException` (base)
  - `MissingRequiredArgumentException`
  - `MissingOptionValueException`
  - `InvalidArgumentValueException`
  - `UnrecognizedArgumentException`

- Added complete constructors (including serialization support) and detailed XML documentation for all exceptions.

- Enhanced `SharpCliHost` to throw these specific exceptions in appropriate scenarios:
  - Duplicate command/alias during registration
  - Invalid command configuration (duplicate parameter names, unsupported return types)
  - Unknown command
  - Missing required arguments/options
  - Invalid argument conversion
  - Unrecognized options or extra positional arguments

- Improved user-facing error messages by catching `SharpCliException` separately and providing clearer feedback.

- Updated and expanded unit tests to cover new exception scenarios and fixed failing tests (`RunAsync_DefaultValues_UsesDefaults`, `RunAsync_UnknownCommand_ReturnsErrorCode`).

- Refactored related code for better validation and consistency.