### PR TITLE
test: add comprehensive unit tests for exception hierarchy and builder factory

### DIFF
--- a/tests/SharpCLI.Tests.UnitTests/AttributesUnitTests/ArgumentAttributeTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/AttributesUnitTests/ArgumentAttributeTests.cs
@@ -1,0 +1,73 @@
+namespace SharpCLI.Tests.UnitTests.AttributesUnitTests;
+
+public class ArgumentAttributeTests
+{
+    [Fact]
+    public void Constructor_WithName_SetsNameAndDefaultProperties()
+    {
+        // Arrange
+        const string expectedName = "filePath";
+
+        // Act
+        var attribute = new ArgumentAttribute(expectedName);
+
+        // Assert
+        Assert.Equal(expectedName, attribute.Name);
+        Assert.Equal(string.Empty, attribute.Description);
+        Assert.True(attribute.Required);
+    }
+
+    [Fact]
+    public void Description_SetAndGet_WorksCorrectly()
+    {
+        // Arrange
+        var attribute = new ArgumentAttribute("input");
+        const string expectedDescription = "The path to the input file.";
+
+        // Act
+        attribute.Description = expectedDescription;
+
+        // Assert
+        Assert.Equal(expectedDescription, attribute.Description);
+    }
+
+    [Fact]
+    public void Required_SetAndGet_WorksCorrectly()
+    {
+        // Arrange
+        var attribute = new ArgumentAttribute("output");
+
+        // Act
+        attribute.Required = false;
+
+        // Assert
+        Assert.False(attribute.Required);
+    }
+
+    [Fact]
+    public void AttributeUsage_IsTargetedToParameters()
+    {
+        // Arrange & Act
+        var usageAttribute = typeof(ArgumentAttribute).GetCustomAttribute<AttributeUsageAttribute>();
+
+        // Assert
+        Assert.NotNull(usageAttribute);
+        Assert.Equal(AttributeTargets.Parameter, usageAttribute.ValidOn);
+    }
+
+    [Fact]
+    public void Properties_WithAllValuesSet_RetainsValues()
+    {
+        // Arrange & Act
+        var attribute = new ArgumentAttribute("count")
+        {
+            Description = "Number of retries",
+            Required = false
+        };
+
+        // Assert
+        Assert.Equal("count", attribute.Name);
+        Assert.Equal("Number of retries", attribute.Description);
+        Assert.False(attribute.Required);
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/AttributesUnitTests/OptionAttributeTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/AttributesUnitTests/OptionAttributeTests.cs
@@ -1,0 +1,90 @@
+namespace SharpCLI.Tests.UnitTests.AttributesUnitTests;
+
+public class OptionAttributeTests
+{
+    [Fact]
+    public void Constructor_WithNames_SetsShortAndLongName()
+    {
+        // Arrange
+        const string shortName = "v";
+        const string longName = "verbose";
+
+        // Act
+        var attribute = new OptionAttribute(shortName, longName);
+
+        // Assert
+        Assert.Equal(shortName, attribute.ShortName);
+        Assert.Equal(longName, attribute.LongName);
+        Assert.Equal(string.Empty, attribute.Description);
+        Assert.Null(attribute.DefaultValue);
+    }
+
+    [Fact]
+    public void Description_SetAndGet_WorksCorrectly()
+    {
+        // Arrange
+        var attribute = new OptionAttribute("o", "output");
+        const string description = "The output directory path.";
+
+        // Act
+        attribute.Description = description;
+
+        // Assert
+        Assert.Equal(description, attribute.Description);
+    }
+
+    [Fact]
+    public void DefaultValue_SetAndGet_WorksWithVariousTypes()
+    {
+        // Arrange
+        var attribute = new OptionAttribute("t", "timeout");
+        const int timeoutValue = 30;
+
+        // Act
+        attribute.DefaultValue = timeoutValue;
+
+        // Assert
+        Assert.Equal(timeoutValue, attribute.DefaultValue);
+    }
+
+    [Fact]
+    public void AttributeUsage_IsTargetedToParameters()
+    {
+        // Arrange & Act
+        var usageAttribute = typeof(OptionAttribute).GetCustomAttribute<AttributeUsageAttribute>();
+
+        // Assert
+        Assert.NotNull(usageAttribute);
+        Assert.Equal(AttributeTargets.Parameter, usageAttribute.ValidOn);
+    }
+
+    [Fact]
+    public void ObjectInitializer_SetsAllPropertiesCorrectly()
+    {
+        // Arrange & Act
+        var attribute = new OptionAttribute("f", "force")
+        {
+            Description = "Force the operation",
+            DefaultValue = true
+        };
+
+        // Assert
+        Assert.Equal("f", attribute.ShortName);
+        Assert.Equal("force", attribute.LongName);
+        Assert.Equal("Force the operation", attribute.Description);
+        Assert.True((bool?)attribute.DefaultValue);
+    }
+
+    [Fact]
+    public void DefaultValue_CanBeSetToNull()
+    {
+        // Arrange
+        var attribute = new OptionAttribute("c", "config") { DefaultValue = "some/path" };
+
+        // Act
+        attribute.DefaultValue = null;
+
+        // Assert
+        Assert.Null(attribute.DefaultValue);
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/Enums/TestLevel.cs
+++ b/tests/SharpCLI.Tests.UnitTests/Enums/TestLevel.cs
@@ -1,4 +1,4 @@
-namespace SharpCLI.Tests.UnitTests;
+namespace SharpCLI.Tests.UnitTests.Enums;
 
 public enum TestLevel
 {

--- a/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/AliasAlreadyExistsExceptionTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/AliasAlreadyExistsExceptionTests.cs
@@ -1,0 +1,114 @@
+namespace SharpCLI.Tests.UnitTests.ExceptionsUnitTests;
+
+public class AliasAlreadyExistsExceptionTests
+{
+    [Fact]
+    public void Constructor_Default_SetsEmptyAlias()
+    {
+        // Act
+        var exception = new AliasAlreadyExistsException();
+
+        // Assert
+        Assert.Equal(string.Empty, exception.Alias);
+    }
+
+    [Fact]
+    public void Constructor_WithAlias_SetsProperties()
+    {
+        // Arrange
+        const string alias = "v";
+
+        // Act
+        var exception = new AliasAlreadyExistsException(alias);
+
+        // Assert
+        Assert.Equal(alias, exception.Alias);
+        Assert.Equal($"An alias '{alias}' is already registered for another command.", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithAliasAndInnerException_SetsProperties()
+    {
+        // Arrange
+        const string alias = "h";
+        var inner = new Exception("Collision detected");
+
+        // Act
+        var exception = new AliasAlreadyExistsException(alias, inner);
+
+        // Assert
+        Assert.Equal(alias, exception.Alias);
+        Assert.Same(inner, exception.InnerException);
+        Assert.Equal($"An alias '{alias}' is already registered for another command.", exception.Message);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_RestoresAlias()
+    {
+        // Arrange
+        const string alias = "duplicate-alias";
+        var info = new SerializationInfo(typeof(AliasAlreadyExistsException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        // Required base Exception fields to prevent SerializationException during base(info, context)
+        info.AddValue("ClassName", typeof(AliasAlreadyExistsException).FullName);
+        info.AddValue("Message", "Custom message");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // The custom field for this exception
+        info.AddValue("Alias", alias);
+
+        // Act - Invoke protected constructor
+        var constructor = typeof(AliasAlreadyExistsException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            new[] { typeof(SerializationInfo), typeof(StreamingContext) },
+            null);
+
+        var exception = (AliasAlreadyExistsException)constructor!.Invoke(new object[] { info, context });
+
+        // Assert
+        Assert.Equal(alias, exception.Alias);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_WithNullAlias_SetsEmptyString()
+    {
+        // Arrange
+        var info = new SerializationInfo(typeof(AliasAlreadyExistsException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        info.AddValue("ClassName", typeof(AliasAlreadyExistsException).FullName);
+        info.AddValue("Message", "Error");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Simulate a null value for Alias in the serialization bag
+        info.AddValue("Alias", null);
+
+        // Act
+        var constructor = typeof(AliasAlreadyExistsException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            new[] { typeof(SerializationInfo), typeof(StreamingContext) },
+            null);
+
+        var exception = (AliasAlreadyExistsException)constructor!.Invoke(new object[] { info, context });
+
+        // Assert
+        Assert.Equal(string.Empty, exception.Alias);
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/ArgumentParsingExceptionTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/ArgumentParsingExceptionTests.cs
@@ -1,0 +1,78 @@
+namespace SharpCLI.Tests.UnitTests.ExceptionsUnitTests;
+
+public class ArgumentParsingExceptionTests
+{
+    [Fact]
+    public void Constructor_Default_InitializesCorrectly()
+    {
+        // Act
+        var exception = new ArgumentParsingException();
+
+        // Assert
+        Assert.NotNull(exception);
+        
+        // Default Exception message usually contains the class name
+        Assert.Contains(nameof(ArgumentParsingException), exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithMessage_SetsMessage()
+    {
+        // Arrange
+        const string message = "Invalid argument provided.";
+
+        // Act
+        var exception = new ArgumentParsingException(message);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithMessageAndInnerException_SetsProperties()
+    {
+        // Arrange
+        const string message = "Parsing failed.";
+        var inner = new FormatException("Invalid format.");
+
+        // Act
+        var exception = new ArgumentParsingException(message, inner);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+        Assert.Same(inner, exception.InnerException);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_InitializesViaReflection()
+    {
+        // Arrange
+        var info = new SerializationInfo(typeof(ArgumentParsingException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        // Mandatory fields required by System.Exception's serialization constructor
+        info.AddValue("ClassName", typeof(ArgumentParsingException).FullName);
+        info.AddValue("Message", "Serialized message");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Act - Invoke the protected serialization constructor
+        var constructor = typeof(ArgumentParsingException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (ArgumentParsingException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.NotNull(exception);
+        Assert.Equal("Serialized message", exception.Message);
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/CommandAlreadyExistsExceptionTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/CommandAlreadyExistsExceptionTests.cs
@@ -1,0 +1,114 @@
+namespace SharpCLI.Tests.UnitTests.ExceptionsUnitTests;
+
+public class CommandAlreadyExistsExceptionTests
+{
+    [Fact]
+    public void Constructor_Default_SetsEmptyCommandName()
+    {
+        // Act
+        var exception = new CommandAlreadyExistsException();
+
+        // Assert
+        Assert.Equal(string.Empty, exception.CommandName);
+    }
+
+    [Fact]
+    public void Constructor_WithCommandName_SetsProperties()
+    {
+        // Arrange
+        const string commandName = "build";
+
+        // Act
+        var exception = new CommandAlreadyExistsException(commandName);
+
+        // Assert
+        Assert.Equal(commandName, exception.CommandName);
+        Assert.Equal($"A command with the name '{commandName}' is already registered.", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithCommandNameAndInnerException_SetsProperties()
+    {
+        // Arrange
+        const string commandName = "deploy";
+        var inner = new Exception("Internal collision");
+
+        // Act
+        var exception = new CommandAlreadyExistsException(commandName, inner);
+
+        // Assert
+        Assert.Equal(commandName, exception.CommandName);
+        Assert.Same(inner, exception.InnerException);
+        Assert.Equal($"A command with the name '{commandName}' is already registered.", exception.Message);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_RestoresCommandName()
+    {
+        // Arrange
+        const string commandName = "test-cmd";
+        var info = new SerializationInfo(typeof(CommandAlreadyExistsException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        // Required base Exception fields for base(info, context)
+        info.AddValue("ClassName", typeof(CommandAlreadyExistsException).FullName);
+        info.AddValue("Message", "Custom message");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Custom field specific to this exception
+        info.AddValue("CommandName", commandName);
+
+        // Act - Invoke protected constructor via reflection
+        var constructor = typeof(CommandAlreadyExistsException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (CommandAlreadyExistsException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.Equal(commandName, exception.CommandName);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_WithNullCommandName_SetsEmptyString()
+    {
+        // Arrange
+        var info = new SerializationInfo(typeof(CommandAlreadyExistsException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        info.AddValue("ClassName", typeof(CommandAlreadyExistsException).FullName);
+        info.AddValue("Message", "Error");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Simulate null entry for CommandName in the serialization bag
+        info.AddValue("CommandName", null);
+
+        // Act
+        var constructor = typeof(CommandAlreadyExistsException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (CommandAlreadyExistsException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.Equal(string.Empty, exception.CommandName);
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/CommandNotFoundExceptionTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/CommandNotFoundExceptionTests.cs
@@ -1,0 +1,114 @@
+namespace SharpCLI.Tests.UnitTests.ExceptionsUnitTests;
+
+public class CommandNotFoundExceptionTests
+{
+    [Fact]
+    public void Constructor_Default_SetsEmptyCommandName()
+    {
+        // Act
+        var exception = new CommandNotFoundException();
+
+        // Assert
+        Assert.Equal(string.Empty, exception.CommandName);
+    }
+
+    [Fact]
+    public void Constructor_WithCommandName_SetsProperties()
+    {
+        // Arrange
+        const string commandName = "unknown";
+
+        // Act
+        var exception = new CommandNotFoundException(commandName);
+
+        // Assert
+        Assert.Equal(commandName, exception.CommandName);
+        Assert.Equal($"Command '{commandName}' not found. Use '--help' for available commands.", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithCommandNameAndInnerException_SetsProperties()
+    {
+        // Arrange
+        const string commandName = "missing-tool";
+        var inner = new Exception("Source system failure");
+
+        // Act
+        var exception = new CommandNotFoundException(commandName, inner);
+
+        // Assert
+        Assert.Equal(commandName, exception.CommandName);
+        Assert.Same(inner, exception.InnerException);
+        Assert.Equal($"Command '{commandName}' not found. Use '--help' for available commands.", exception.Message);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_RestoresCommandName()
+    {
+        // Arrange
+        const string commandName = "ghost-command";
+        var info = new SerializationInfo(typeof(CommandNotFoundException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        // Required base Exception fields for base(info, context)
+        info.AddValue("ClassName", typeof(CommandNotFoundException).FullName);
+        info.AddValue("Message", "Custom message");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Custom field for CommandNotFoundException
+        info.AddValue("CommandName", commandName);
+
+        // Act - Invoke protected constructor via reflection
+        var constructor = typeof(CommandNotFoundException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (CommandNotFoundException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.Equal(commandName, exception.CommandName);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_WithNullCommandName_SetsEmptyString()
+    {
+        // Arrange
+        var info = new SerializationInfo(typeof(CommandNotFoundException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        info.AddValue("ClassName", typeof(CommandNotFoundException).FullName);
+        info.AddValue("Message", "Error");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Simulate a null entry to test the null-coalescing logic
+        info.AddValue("CommandName", null);
+
+        // Act
+        var constructor = typeof(CommandNotFoundException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (CommandNotFoundException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.Equal(string.Empty, exception.CommandName);
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/CommandRegistrationExceptionTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/CommandRegistrationExceptionTests.cs
@@ -1,0 +1,76 @@
+namespace SharpCLI.Tests.UnitTests.ExceptionsUnitTests;
+
+public class CommandRegistrationExceptionTests
+{
+    [Fact]
+    public void Constructor_Default_InitializesCorrectly()
+    {
+        // Act
+        var exception = new CommandRegistrationException();
+
+        // Assert
+        Assert.NotNull(exception);
+        Assert.Contains(nameof(CommandRegistrationException), exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithMessage_SetsMessage()
+    {
+        // Arrange
+        const string message = "Failed to register command 'test'.";
+
+        // Act
+        var exception = new CommandRegistrationException(message);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithMessageAndInnerException_SetsProperties()
+    {
+        // Arrange
+        const string message = "Registration error.";
+        var inner = new Exception("Constraint violation.");
+
+        // Act
+        var exception = new CommandRegistrationException(message, inner);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+        Assert.Same(inner, exception.InnerException);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_InitializesViaReflection()
+    {
+        // Arrange
+        var info = new SerializationInfo(typeof(CommandRegistrationException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        // Standard Exception fields required for successful base(info, context) call
+        info.AddValue("ClassName", typeof(CommandRegistrationException).FullName);
+        info.AddValue("Message", "Serialized registration error");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Act - Access the protected constructor
+        var constructor = typeof(CommandRegistrationException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (CommandRegistrationException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.NotNull(exception);
+        Assert.Equal("Serialized registration error", exception.Message);
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/InvalidCommandConfigurationExceptionTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/InvalidCommandConfigurationExceptionTests.cs
@@ -1,0 +1,76 @@
+namespace SharpCLI.Tests.UnitTests.ExceptionsUnitTests;
+
+public class InvalidCommandConfigurationExceptionTests
+{
+    [Fact]
+    public void Constructor_Default_InitializesCorrectly()
+    {
+        // Act
+        var exception = new InvalidCommandConfigurationException();
+
+        // Assert
+        Assert.NotNull(exception);
+        Assert.Contains(nameof(InvalidCommandConfigurationException), exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithMessage_SetsMessage()
+    {
+        // Arrange
+        const string message = "Command 'run' is missing a required handler.";
+
+        // Act
+        var exception = new InvalidCommandConfigurationException(message);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithMessageAndInnerException_SetsProperties()
+    {
+        // Arrange
+        const string message = "Configuration error.";
+        var inner = new InvalidOperationException("Dependency not met.");
+
+        // Act
+        var exception = new InvalidCommandConfigurationException(message, inner);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+        Assert.Same(inner, exception.InnerException);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_InitializesViaReflection()
+    {
+        // Arrange
+        var info = new SerializationInfo(typeof(InvalidCommandConfigurationException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        // Mandatory fields required by System.Exception's serialization constructor
+        info.AddValue("ClassName", typeof(InvalidCommandConfigurationException).FullName);
+        info.AddValue("Message", "Serialized config error");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Act - Invoke the protected serialization constructor
+        var constructor = typeof(InvalidCommandConfigurationException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (InvalidCommandConfigurationException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.NotNull(exception);
+        Assert.Equal("Serialized config error", exception.Message);
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/MissingOptionValueExceptionTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/MissingOptionValueExceptionTests.cs
@@ -1,0 +1,115 @@
+namespace SharpCLI.Tests.UnitTests.ExceptionsUnitTests;
+
+public class MissingOptionValueExceptionTests
+{
+    [Fact]
+    public void Constructor_Default_SetsEmptyOptionName()
+    {
+        // Act
+        var exception = new MissingOptionValueException();
+
+        // Assert
+        Assert.Equal(string.Empty, exception.OptionName);
+    }
+
+    [Fact]
+    public void Constructor_WithOptionName_SetsProperties()
+    {
+        // Arrange
+        const string optionName = "threshold";
+
+        // Act
+        var exception = new MissingOptionValueException(optionName);
+
+        // Assert
+        Assert.Equal(optionName, exception.OptionName);
+        Assert.Equal($"Option '{optionName}' requires a value but none was provided.", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithOptionNameAndInnerException_SetsProperties()
+    {
+        // Arrange
+        const string optionName = "output";
+        var inner = new Exception("Root cause");
+
+        // Act
+        var exception = new MissingOptionValueException(optionName, inner);
+
+        // Assert
+        Assert.Equal(optionName, exception.OptionName);
+        Assert.Same(inner, exception.InnerException);
+        Assert.Equal($"Option '{optionName}' requires a value but none was provided.", exception.Message);
+    }
+    
+    [Fact]
+    public void SerializationConstructor_ValidInfo_SetsOptionName()
+    {
+        // Arrange
+        var info = new SerializationInfo(typeof(MissingOptionValueException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        // We must provide the fields that the 'base(info, context)' call expects
+        // to avoid "Member 'Message' not found" errors.
+        info.AddValue("ClassName", typeof(MissingOptionValueException).FullName);
+        info.AddValue("Message", "Custom error message");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088); // Standard Exception HResult
+        info.AddValue("Source", null);
+
+        // This is the specific line your constructor logic depends on:
+        info.AddValue("OptionName", "test-option");
+
+        // Act - Invoke the protected constructor via reflection
+        var constructor = typeof(MissingOptionValueException).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (MissingOptionValueException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.Equal("test-option", exception.OptionName);
+    }
+
+    [Fact]
+    public void SerializationConstructor_NullOptionName_SetsEmptyString()
+    {
+        // Arrange
+        var info = new SerializationInfo(typeof(MissingOptionValueException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        // Populate mandatory base exception fields
+        info.AddValue("ClassName", typeof(MissingOptionValueException).FullName);
+        info.AddValue("Message", "Error");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Simulate a null value for OptionName to test the '?? string.Empty' logic
+        info.AddValue("OptionName", null);
+
+        // Act
+        var constructor = typeof(MissingOptionValueException).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (MissingOptionValueException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.Equal(string.Empty, exception.OptionName);
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/MissingRequiredArgumentExceptionTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/MissingRequiredArgumentExceptionTests.cs
@@ -1,0 +1,114 @@
+namespace SharpCLI.Tests.UnitTests.ExceptionsUnitTests;
+
+public class MissingRequiredArgumentExceptionTests
+{
+    [Fact]
+    public void Constructor_Default_SetsEmptyArgumentName()
+    {
+        // Act
+        var exception = new MissingRequiredArgumentException();
+
+        // Assert
+        Assert.Equal(string.Empty, exception.ArgumentName);
+    }
+
+    [Fact]
+    public void Constructor_WithArgumentName_SetsProperties()
+    {
+        // Arrange
+        const string argName = "filePath";
+
+        // Act
+        var exception = new MissingRequiredArgumentException(argName);
+
+        // Assert
+        Assert.Equal(argName, exception.ArgumentName);
+        Assert.Equal($"Required argument '{argName}' is missing.", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithArgumentNameAndInnerException_SetsProperties()
+    {
+        // Arrange
+        const string argName = "input";
+        var inner = new Exception("Root cause");
+
+        // Act
+        var exception = new MissingRequiredArgumentException(argName, inner);
+
+        // Assert
+        Assert.Equal(argName, exception.ArgumentName);
+        Assert.Same(inner, exception.InnerException);
+        Assert.Equal($"Required argument '{argName}' is missing.", exception.Message);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_RestoresArgumentName()
+    {
+        // Arrange
+        const string argName = "config-path";
+        var info = new SerializationInfo(typeof(MissingRequiredArgumentException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        // Required base Exception fields for base(info, context)
+        info.AddValue("ClassName", typeof(MissingRequiredArgumentException).FullName);
+        info.AddValue("Message", "Custom message");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Custom field
+        info.AddValue("ArgumentName", argName);
+
+        // Act - Invoke protected constructor via reflection
+        var constructor = typeof(MissingRequiredArgumentException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (MissingRequiredArgumentException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.Equal(argName, exception.ArgumentName);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_WithNullArgumentName_SetsEmptyString()
+    {
+        // Arrange
+        var info = new SerializationInfo(typeof(MissingRequiredArgumentException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        info.AddValue("ClassName", typeof(MissingRequiredArgumentException).FullName);
+        info.AddValue("Message", "Error");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Simulate null entry for ArgumentName
+        info.AddValue("ArgumentName", null);
+
+        // Act
+        var constructor = typeof(MissingRequiredArgumentException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (MissingRequiredArgumentException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.Equal(string.Empty, exception.ArgumentName);
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/UnrecognizedArgumentExceptionTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/ExceptionsUnitTests/UnrecognizedArgumentExceptionTests.cs
@@ -1,0 +1,114 @@
+namespace SharpCLI.Tests.UnitTests.ExceptionsUnitTests;
+
+public class UnrecognizedArgumentExceptionTests
+{
+    [Fact]
+    public void Constructor_Default_SetsEmptyUnrecognizedArg()
+    {
+        // Act
+        var exception = new UnrecognizedArgumentException();
+
+        // Assert
+        Assert.Equal(string.Empty, exception.UnrecognizedArg);
+    }
+
+    [Fact]
+    public void Constructor_WithUnrecognizedArg_SetsProperties()
+    {
+        // Arrange
+        const string arg = "--unknown-flag";
+
+        // Act
+        var exception = new UnrecognizedArgumentException(arg);
+
+        // Assert
+        Assert.Equal(arg, exception.UnrecognizedArg);
+        Assert.Equal($"Unrecognized argument or option: '{arg}'.", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithUnrecognizedArgAndInnerException_SetsProperties()
+    {
+        // Arrange
+        const string arg = "invalid-param";
+        var inner = new Exception("Validation failed");
+
+        // Act
+        var exception = new UnrecognizedArgumentException(arg, inner);
+
+        // Assert
+        Assert.Equal(arg, exception.UnrecognizedArg);
+        Assert.Same(inner, exception.InnerException);
+        Assert.Equal($"Unrecognized argument or option: '{arg}'.", exception.Message);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_RestoresUnrecognizedArg()
+    {
+        // Arrange
+        const string arg = "unexpected-token";
+        var info = new SerializationInfo(typeof(UnrecognizedArgumentException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        // Mandatory fields required by System.Exception's serialization constructor
+        info.AddValue("ClassName", typeof(UnrecognizedArgumentException).FullName);
+        info.AddValue("Message", "Custom error message");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // The property-specific data
+        info.AddValue("UnrecognizedArg", arg);
+
+        // Act - Invoke the protected constructor via reflection
+        var constructor = typeof(UnrecognizedArgumentException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (UnrecognizedArgumentException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.Equal(arg, exception.UnrecognizedArg);
+    }
+
+    [Fact]
+    public void Serialization_Constructor_WithNullUnrecognizedArg_SetsEmptyString()
+    {
+        // Arrange
+        var info = new SerializationInfo(typeof(UnrecognizedArgumentException), new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+
+        info.AddValue("ClassName", typeof(UnrecognizedArgumentException).FullName);
+        info.AddValue("Message", "Error");
+        info.AddValue("Data", null);
+        info.AddValue("InnerException", null);
+        info.AddValue("HelpURL", null);
+        info.AddValue("StackTraceString", null);
+        info.AddValue("RemoteStackTraceString", null);
+        info.AddValue("RemoteStackIndex", 0);
+        info.AddValue("HResult", -2146233088);
+        info.AddValue("Source", null);
+
+        // Simulate a null entry in the serialization data to test the '?? string.Empty' logic
+        info.AddValue("UnrecognizedArg", null);
+
+        // Act
+        var constructor = typeof(UnrecognizedArgumentException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            [typeof(SerializationInfo), typeof(StreamingContext)],
+            null);
+
+        var exception = (UnrecognizedArgumentException)constructor!.Invoke([info, context]);
+
+        // Assert
+        Assert.Equal(string.Empty, exception.UnrecognizedArg);
+    }
+}

--- a/tests/SharpCLI.Tests.UnitTests/GlobalUsings.cs
+++ b/tests/SharpCLI.Tests.UnitTests/GlobalUsings.cs
@@ -1,5 +1,6 @@
 global using Xunit;
 global using SharpCLI.Tests.UnitTests.Commands;
+global using SharpCLI.Tests.UnitTests.Enums;
 global using System.Globalization;
 global using System.Reflection;
 global using System.Runtime.Serialization;

--- a/tests/SharpCLI.Tests.UnitTests/SharpCliHostUnitTests.cs
+++ b/tests/SharpCLI.Tests.UnitTests/SharpCliHostUnitTests.cs
@@ -639,4 +639,45 @@ public class SharpCliHostUnitTests
         Assert.Contains("a-cmd | Alpha description", output);
         Assert.Contains("z-cmd | Zebra description", output);
     }
+
+    [Fact]
+    public void CreateBuilder_ReturnsNewBuilderInstance()
+    {
+        // Act
+        var builder = SharpCliHost.CreateBuilder();
+
+        // Assert
+        Assert.NotNull(builder);
+        Assert.IsType<SharpCliHostBuilder>(builder);
+    }
+
+    [Fact]
+    public void CreateBuilder_ProducesIndependentInstances()
+    {
+        // Act
+        var builder1 = SharpCliHost.CreateBuilder();
+        var builder2 = SharpCliHost.CreateBuilder();
+
+        // Assert
+        Assert.NotSame(builder1, builder2);
+    }
+
+    [Fact]
+    public void CreateBuilder_AllowsFluentChainingImmediately()
+    {
+        // Act
+        var host = SharpCliHost.CreateBuilder()
+            .Name("TestApp")
+            .Description("Testing Builder Factory")
+            .Build();
+
+        // Assert
+        Assert.NotNull(host);
+
+        var nameField = typeof(SharpCliHost).GetField("_name",
+            BindingFlags.NonPublic |
+            BindingFlags.Instance);
+
+        Assert.Equal("TestApp", nameField?.GetValue(host));
+    }
 }


### PR DESCRIPTION
- Add tests for SharpCliHost.CreateBuilder to ensure proper instance isolation.
- Add exhaustive tests for the exception hierarchy (ArgumentParsingException, MissingOptionValueException, etc.) using reflection.
- Validate Attribute usage and default property values for Argument and Option attributes.