### PR TITLE
fix: ensure commands without descriptions are visible in help

### DIFF
--- a/src/SharpCLI/SharpCLI.csproj
+++ b/src/SharpCLI/SharpCLI.csproj
@@ -10,7 +10,7 @@
 
     <PropertyGroup>
         <PackageId>SharpCLI</PackageId>
-        <Version>1.5.3</Version>
+        <Version>1.5.4</Version>
         <Title>SharpCli - Modern CLI Framework for .NET</Title>
         <Summary>Attribute-based CLI framework for .NET with automatic parsing and help generation</Summary>
         <Description>A modern, attribute-based CLI framework for .NET that makes building command-line applications simple and intuitive. Transform your methods into powerful CLI commands using simple attributes with automatic argument parsing, help generation, and async support.</Description>

--- a/src/SharpCLI/SharpCliHost.cs
+++ b/src/SharpCLI/SharpCliHost.cs
@@ -592,12 +592,14 @@ public class SharpCliHost : IDisposable
         await _writer.WriteLineAsync($" {_name} <command> [options] [arguments]\n");
 
         if (!_commands.IsEmpty) await _writer.WriteLineAsync("COMMANDS:");
+
         foreach (var item in _commands.OrderBy(kvp => kvp.Key))
         {
-            if (!string.IsNullOrWhiteSpace(item.Value.Description))
-            {
-                await _writer.WriteAsync($"\t{item.Key} | {item.Value.Description}\n");
-            }
+            var description = string.IsNullOrWhiteSpace(item.Value.Description)
+                ? ""
+                : $" | {item.Value.Description}";
+
+            await _writer.WriteAsync($"\t{item.Key}{description}\n");
         }
 
         await _writer.WriteLineAsync($"\nUse '{_name} <command> --help' for more information about a command.");

--- a/tests/SharpCLI.Tests.UnitTests/Commands/UndocumentedCommands.cs
+++ b/tests/SharpCLI.Tests.UnitTests/Commands/UndocumentedCommands.cs
@@ -1,0 +1,10 @@
+namespace SharpCLI.Tests.UnitTests.Commands;
+
+public class UndocumentedCommands : ICommandsContainer
+{
+    [Command("documented-cmd", Description = "Has a description")]
+    public void Documented() { }
+
+    [Command("undocumented-cmd")]
+    public void Undocumented() { }
+}


### PR DESCRIPTION
- Modified ShowHelpAsync to list all registered commands regardless of description status
- Fixed logic that silently hid undocumented commands from the USAGE menu
- Bumped version from 1.5.3 to 1.5.4