### PR TITLE
refactor: simplify IDisposable by sealing SharpCliHost

### DIFF
--- a/src/SharpCLI/SharpCliHost.cs
+++ b/src/SharpCLI/SharpCliHost.cs
@@ -17,7 +17,7 @@ using ParameterInfo = Models.ParameterInfo;
 /// Main host class for SharpCli framework that manages CLI commands, arguments, and options.
 /// Provides an attribute-based approach for building command-line applications in C#.
 /// </summary>
-public class SharpCliHost : IDisposable
+public sealed class SharpCliHost : IDisposable
 {
     /// <summary>
     /// Dictionary storing all registered commands by their names


### PR DESCRIPTION
- Mark SharpCliHost as sealed to bypass inheritance-based Dispose rules